### PR TITLE
Bump base and template-haskell dependencies

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,7 +30,7 @@ flags:
     default: false
 
 dependencies:
-  - base >= 4.18.2 && < 4.20
+  - base >= 4.18.2 && <= 4.21
   - protolude >= 0.3.4 && < 0.4
   - text >= 2.0 && < 2.2
   - sqlite-simple >= 0.4.19 && < 0.5
@@ -98,7 +98,7 @@ library:
     - servant-multipart >= 0.12.1 && < 0.13
     - servant-server >= 0.20 && < 0.21
     - simple-sql-parser >= 0.6 && < 0.9
-    - template-haskell >= 2.20.0 && < 2.22
+    - template-haskell >= 2.20.0 && <= 2.23
     - time >= 1.12.2 && < 1.13
     - typed-process >= 0.2.11 && < 0.3
     - unix >= 2.8.4 && < 2.9


### PR DESCRIPTION
I am trying to install `tasklite` through Nix packages. The package is currently marked as broken, and I want to fix that.

One of `tasklite`'s dependencies is `airgql`, which is also marked as broken in Nix packages. The likely reason is that the Haskell package snapshot in Nix packages doesn't have the necessary versions of all dependencies to satisfy the　version bounds from `package.yaml`.

Here's the error I currently get in `nixpkgs`:

```text
error: builder for '/nix/store/r46vjjwvpmvhzvbi15gcl1v0fd2sk922-airgql-0.7.1.3.drv' failed with exit code 1;
       last 10 log lines:
       > CallStack (from HasCallStack):
       >   withMetadata, called at libraries/Cabal/Cabal/src/Distribution/Simple/Utils.hs:368:14 in Cabal-3.10.3.0-dc39:Dist
ribution.Simple.Utils
       > Error: Setup: Encountered missing or private dependencies:
       > base >=4.18.2 && <4.19,
       > bytestring >=0.11.5 && <0.12,
       > graphql >=1.2.0.1 && <1.4,
       > simple-sql-parser >=0.6.1 && <0.8,
       > template-haskell >=2.20.0 && <2.21,
       > text >=2.0.2 && <2.1
       >
       For full logs, run 'nix log /nix/store/r46vjjwvpmvhzvbi15gcl1v0fd2sk922-airgql-0.7.1.3.drv'.
```

Notice that the bounds shown here are not the bounds that `airgql` currently uses on `master`, rather, they're the bounds of the current [Hackage package source](https://hackage.haskell.org/package/airgql).

With this pull request I tried to update all remaining dependencies that are still out of date with regards to `nixpkgs`. The tests pass, with the exception of the maths functions, but that test also doesn't pass for me on `master`.

However, I don't have much faith in my local test setup. I don't use Stack myself and as such have very little knowledge about it. I created a `flake.nix` file that provides me with Cabal, Stack and GHC, then I run `stack init` followed by `cabal test`. Not sure to what degree that deviates from how you maintainers work with this repo. 

I have full understanding if you say you don't want any churn just to make Nix users happy! But I thought I'd open the PR anyway.

